### PR TITLE
Fixed Pros, Cons and Advice to Management, Helpful count, Pagination error, Years at the company bug

### DIFF
--- a/main.py
+++ b/main.py
@@ -331,8 +331,8 @@ def navigate_to_reviews():
         logger.info('No reviews to scrape. Bailing!')
         return False
 
-    reviews_cell = browser.find_element_by_xpath(
-        "//*[@id='EIProductHeaders']/div/a[2]")
+    reviews_cell = browser.find_element_by_css_selector(
+        "a.eiCell.cell.reviews")
     reviews_path = reviews_cell.get_attribute('href')
     browser.get(reviews_path)
     time.sleep(1)


### PR DESCRIPTION
Also added the control statement when the reviews are over and the reviews to be scraped are more than asked for. e.g. , you asked for 1000 reviews to be scraped but there are only 156. So this change will stop the infinite loop which is inside the extract_from_page function.

    if(len(reviews)== 0):
        logger.info('No more Review!')
        date_limit_reached[0] = True